### PR TITLE
Add unit tests for org.dromara.hmily.common.utils.StringUtils

### DIFF
--- a/hmily-common/pom.xml
+++ b/hmily-common/pom.xml
@@ -81,6 +81,12 @@
             <artifactId>mongo-java-driver</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/hmily-common/src/test/java/org/dromara/hmily/common/utils/StringUtilsTest.java
+++ b/hmily-common/src/test/java/org/dromara/hmily/common/utils/StringUtilsTest.java
@@ -1,0 +1,34 @@
+package org.dromara.hmily.common.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class StringUtilsTest {
+
+    @Test
+    public void testIsNoneBlank() {
+        Assert.assertFalse(StringUtils.isNoneBlank(null));
+        Assert.assertFalse(StringUtils.isNoneBlank(""));
+        Assert.assertFalse(StringUtils.isNoneBlank("", "", ""));
+
+        Assert.assertTrue(StringUtils.isNoneBlank("a", "b", "c"));
+    }
+
+    @Test
+    public void testIsEmpty() {
+        Assert.assertTrue(StringUtils.isEmpty(null));
+        Assert.assertTrue(StringUtils.isEmpty(new String[0]));
+
+        Assert.assertFalse(StringUtils.isEmpty(new String[]{"a", "b", "c"}));
+    }
+
+    @Test
+    public void testIsBlank() {
+        Assert.assertTrue(StringUtils.isBlank(null));
+        Assert.assertTrue(StringUtils.isBlank(""));
+        Assert.assertTrue(StringUtils.isBlank(" "));
+
+        Assert.assertFalse(StringUtils.isBlank("foobar"));
+        Assert.assertFalse(StringUtils.isBlank("foo bar"));
+    }
+}


### PR DESCRIPTION
I've analysed your codebase and noticed that `org.dromara.hmily.common.utils.StringUtils` is not fully tested.
I've written some tests for the methods in this class with the help of [Diffblue Cover](https://www.diffblue.com/opensource).

Hopefully, these tests will help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other classes that you consider important in a subsequent PR.